### PR TITLE
Modification of treatment of  double-width character (e.g. Japanese)

### DIFF
--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -1494,8 +1494,6 @@ void TerminalDisplay::drawContents(QPainter &paint, const QRect &rect)
             bool save__fixedFont = _fixedFont;
          if (lineDraw)
             _fixedFont = false;
-         if (doubleWidth)
-            _fixedFont = false;
          unistr.resize(p);
 
          // Create a text scaling matrix for double width and double height lines.

--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -1497,7 +1497,7 @@ void TerminalDisplay::drawContents(QPainter &paint, const QRect &rect)
          unistr.resize(p);
 
          // Create a text scaling matrix for double width and double height lines.
-         QMatrix textScale;
+         QTransform textScale;
 
          if (y < _lineProperties.size())
          {
@@ -1509,7 +1509,7 @@ void TerminalDisplay::drawContents(QPainter &paint, const QRect &rect)
          }
 
          //Apply text scaling matrix.
-         paint.setWorldMatrix(textScale, true);
+         paint.setWorldTransform(textScale, true);
 
          //calculate the area in which the text will be drawn
          QRect textArea = calculateTextArea(tLx, tLy, x, y, len);
@@ -1533,7 +1533,7 @@ void TerminalDisplay::drawContents(QPainter &paint, const QRect &rect)
          _fixedFont = save__fixedFont;
 
          //reset back to single-width, single-height _lines
-         paint.setWorldMatrix(textScale.inverted(), true);
+         paint.setWorldTransform(textScale.inverted(), true);
 
          if (y < _lineProperties.size()-1)
          {


### PR DESCRIPTION
I am Japanese user, and I am annoyed about the problem of  textline alignment  including Japanese double width characters shown as this picture.
![image0023-2](https://cloud.githubusercontent.com/assets/6244624/12174111/06a017a2-b59e-11e5-8373-5b73cf0cfde3.png)

The reason is that fontwidth of Japanese double-width character is not exactly twice that of single-width character. 
My suggestion is delete the code which treats fontwidth of double-width character as proportional font.  

The Result of this modification is shown this picture;
![image0024-2](https://cloud.githubusercontent.com/assets/6244624/12175157/22474326-b5a4-11e5-837f-7b7495d32be4.png)

BTW, setWorldMatrix function for Qpainter is obsolete.  SetWorldTransform function should be used instead of setWorldMatrix.