### PR TITLE
Fix ASan error about delete size mismatch

### DIFF
--- a/lib/kprocess.h
+++ b/lib/kprocess.h
@@ -355,6 +355,9 @@ protected:
         openMode(QIODevice::ReadWrite)
     {
     }
+    virtual ~KProcessPrivate()
+    {
+    }
     void writeAll(const QByteArray &buf, int fd);
     void forwardStd(KProcess::ProcessChannel good, int fd);
     void _k_forwardStdout();


### PR DESCRIPTION
A derived version of this object was new'ed in one place, but it's stored and deleted in a pointer of this base class. When that happens AddressSanitizer spews because the delete call is the wrong size (since it's only the size of the base class, not the derived class).

Marking the destructor as virtual fixes the problem.