### PR TITLE
Remove widget size checks in setVTFont()

### DIFF
--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -263,21 +263,18 @@ void TerminalDisplay::setVTFont(const QFont& f)
       qDebug() << "Using a variable-width font in the terminal.  This may cause performance degradation and display/alignment errors.";
   }
 
-  if ( metrics.height() < height() && metrics.maxWidth() < width() )
-  {
-    // hint that text should be drawn without anti-aliasing.
-    // depending on the user's font configuration, this may not be respected
-    if (!_antialiasText)
-        font.setStyleStrategy( QFont::NoAntialias );
+  // hint that text should be drawn without anti-aliasing.
+  // depending on the user's font configuration, this may not be respected
+  if (!_antialiasText)
+      font.setStyleStrategy( QFont::NoAntialias );
 
-    // experimental optimization.  Konsole assumes that the terminal is using a
-    // mono-spaced font, in which case kerning information should have an effect.
-    // Disabling kerning saves some computation when rendering text.
-    font.setKerning(false);
+  // experimental optimization.  Konsole assumes that the terminal is using a
+  // mono-spaced font, in which case kerning information should have an effect.
+  // Disabling kerning saves some computation when rendering text.
+  font.setKerning(false);
 
-    QWidget::setFont(font);
-    fontChange(font);
-  }
+  QWidget::setFont(font);
+  fontChange(font);
 }
 
 void TerminalDisplay::setFont(const QFont &)


### PR DESCRIPTION
This fixes https://github.com/lxde/qterminal/issues/125
The removed check caused the widget to ignore the set font value when its metrics exceeded default 100x30 widget dimensions effective during initialization.
I've tested the changes with fonts much larger than the actual viewport and those seems to work as expected, so these checks seems to be outdated and harmful.