### PR TITLE
Report cursor locations to IME whenever there's a keyboard event

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,7 @@ set(HDRS
     lib/kptyprocess.h
     lib/Pty.h
     lib/qtermwidget.h
+    lib/Screen.h
     lib/ScreenWindow.h
     lib/SearchBar.h
     lib/Session.h

--- a/lib/Screen.cpp
+++ b/lib/Screen.cpp
@@ -108,6 +108,7 @@ void Screen::cursorUp(int n)
     int stop = cuY < _topMargin ? 0 : _topMargin;
     cuX = qMin(columns-1,cuX); // nowrap!
     cuY = qMax(stop,cuY-n);
+    emit cursorLocationChanged();
 }
 
 void Screen::cursorDown(int n)
@@ -117,6 +118,7 @@ void Screen::cursorDown(int n)
     int stop = cuY > _bottomMargin ? lines-1 : _bottomMargin;
     cuX = qMin(columns-1,cuX); // nowrap!
     cuY = qMin(stop,cuY+n);
+    emit cursorLocationChanged();
 }
 
 void Screen::cursorLeft(int n)
@@ -125,6 +127,7 @@ void Screen::cursorLeft(int n)
     if (n == 0) n = 1; // Default
     cuX = qMin(columns-1,cuX); // nowrap!
     cuX = qMax(0,cuX-n);
+    emit cursorLocationChanged();
 }
 
 void Screen::cursorRight(int n)
@@ -132,6 +135,7 @@ void Screen::cursorRight(int n)
 {
     if (n == 0) n = 1; // Default
     cuX = qMin(columns-1,cuX+n);
+    emit cursorLocationChanged();
 }
 
 void Screen::setMargins(int top, int bot)
@@ -149,6 +153,7 @@ void Screen::setMargins(int top, int bot)
     _bottomMargin = bot;
     cuX = 0;
     cuY = getMode(MODE_Origin) ? top : 0;
+    emit cursorLocationChanged();
 
 }
 
@@ -168,6 +173,7 @@ void Screen::index()
         scrollUp(1);
     else if (cuY < lines-1)
         cuY += 1;
+    emit cursorLocationChanged();
 }
 
 void Screen::reverseIndex()
@@ -177,6 +183,7 @@ void Screen::reverseIndex()
         scrollDown(_topMargin,1);
     else if (cuY > 0)
         cuY -= 1;
+    emit cursorLocationChanged();
 }
 
 void Screen::nextLine()
@@ -243,7 +250,7 @@ void Screen::setMode(int m)
     currentModes[m] = true;
     switch(m)
     {
-        case MODE_Origin : cuX = 0; cuY = _topMargin; break; //FIXME: home
+        case MODE_Origin : cuX = 0; cuY = _topMargin; emit cursorLocationChanged(); break; //FIXME: home
     }
 }
 
@@ -252,7 +259,7 @@ void Screen::resetMode(int m)
     currentModes[m] = false;
     switch(m)
     {
-        case MODE_Origin : cuX = 0; cuY = 0; break; //FIXME: home
+        case MODE_Origin : cuX = 0; cuY = 0; emit cursorLocationChanged(); break; //FIXME: home
     }
 }
 
@@ -288,6 +295,7 @@ void Screen::restoreCursor()
     currentForeground   = savedState.foreground;
     currentBackground   = savedState.background;
     updateEffectiveRendition();
+    emit cursorLocationChanged();
 }
 
 void Screen::resizeImage(int new_lines, int new_columns)
@@ -324,6 +332,7 @@ void Screen::resizeImage(int new_lines, int new_columns)
     columns = new_columns;
     cuX = qMin(cuX,columns-1);
     cuY = qMin(cuY,lines-1);
+    emit cursorLocationChanged();
 
     // FIXME: try to keep values, evtl.
     _topMargin=0;
@@ -557,6 +566,8 @@ void Screen::backspace()
 
     if (BS_CLEARS)
         screenLines[cuY][cuX].character = ' ';
+
+    emit cursorLocationChanged();
 }
 
 void Screen::tab(int n)
@@ -681,6 +692,7 @@ void Screen::displayCharacter(unsigned short c)
         w--;
     }
     cuX = newCursorX;
+    emit cursorLocationChanged();
 }
 
 void Screen::compose(const QString& /*compose*/)
@@ -768,6 +780,7 @@ void Screen::setCursorX(int x)
     if (x == 0) x = 1; // Default
     x -= 1; // Adjust
     cuX = qMax(0,qMin(columns-1, x));
+    emit cursorLocationChanged();
 }
 
 void Screen::setCursorY(int y)
@@ -775,17 +788,20 @@ void Screen::setCursorY(int y)
     if (y == 0) y = 1; // Default
     y -= 1; // Adjust
     cuY = qMax(0,qMin(lines  -1, y + (getMode(MODE_Origin) ? _topMargin : 0) ));
+    emit cursorLocationChanged();
 }
 
 void Screen::home()
 {
     cuX = 0;
     cuY = 0;
+    emit cursorLocationChanged();
 }
 
 void Screen::toStartOfLine()
 {
     cuX = 0;
+    emit cursorLocationChanged();
 }
 
 int Screen::getCursorX() const

--- a/lib/Screen.h
+++ b/lib/Screen.h
@@ -68,8 +68,10 @@ class TerminalCharacterDecoder;
     using selectedText().  When getImage() is used to retrieve the visible image,
     characters which are part of the selection have their colours inverted.
 */
-class Screen
+class Screen : public QObject
 {
+    Q_OBJECT
+
 public:
     /** Construct a new screen image of size @p lines by @p columns. */
     Screen(int lines, int columns);
@@ -544,6 +546,12 @@ public:
       * Character style.
       */
     static void fillWithDefaultChar(Character* dest, int count);
+
+signals:
+    /**
+      * Triggered when either cuX or cuY is changed
+      */
+    void cursorLocationChanged();
 
 private:
 

--- a/lib/ScreenWindow.cpp
+++ b/lib/ScreenWindow.cpp
@@ -48,6 +48,9 @@ void ScreenWindow::setScreen(Screen* screen)
     Q_ASSERT( screen );
 
     _screen = screen;
+
+    connect(_screen, &Screen::cursorLocationChanged,
+            this, &ScreenWindow::cursorLocationChanged);
 }
 
 Screen* ScreenWindow::screen() const

--- a/lib/ScreenWindow.h
+++ b/lib/ScreenWindow.h
@@ -239,6 +239,11 @@ signals:
     /** Emitted when the selection is changed. */
     void selectionChanged();
 
+    /**
+     * Triggered when the cursor location is changed
+     */
+    void cursorLocationChanged();
+
 private:
     int endWindowLine() const;
     void fillUnusedArea();

--- a/lib/TerminalDisplay.h
+++ b/lib/TerminalDisplay.h
@@ -609,6 +609,8 @@ protected slots:
     //after emitting the first in a sequence of bell events.
     void enableBell();
 
+    void updateIMECursorRectangle();
+
 private slots:
 
     void swapColorTable();
@@ -806,6 +808,7 @@ private:
     {
         QString preeditString;
         QRect previousPreeditRect;
+        int cursorPos;
     };
     InputMethodData _inputMethodData;
 


### PR DESCRIPTION
Fixes #85.

![screenshot from 2016-08-29 03-06-21](https://cloud.githubusercontent.com/assets/1937689/18044605/475d2dfe-6e01-11e6-8f2a-662cc220f4e8.png)

In this PR I also replace the deprecated symbol `ImMicroFocus` with the recommended one. [1]

[1] http://doc.qt.io/qt-5/qt.html#InputMethodQuery-enum
