### PR TITLE
WIP: Display wide characters correctly (part 2)

### DIFF
--- a/lib/Character.h
+++ b/lib/Character.h
@@ -78,7 +78,7 @@ public:
   union
   {
     /** The unicode character value for this character. */
-    quint16 character;
+    wchar_t character;
     /**
      * Experimental addition which allows a single Character instance to contain more than
      * one unicode character.

--- a/lib/Emulation.cpp
+++ b/lib/Emulation.cpp
@@ -26,6 +26,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <string>
 
 // Qt
 #include <QApplication>
@@ -188,7 +189,7 @@ QString Emulation::keyBindings() const
   return _keyTranslator->name();
 }
 
-void Emulation::receiveChar(int c)
+void Emulation::receiveChar(wchar_t c)
 // process application unicode input to terminal
 // this is a trivial scanner
 {
@@ -238,11 +239,12 @@ void Emulation::receiveData(const char* text, int length)
 
     bufferedUpdate();
 
-    QString unicodeText = _decoder->toUnicode(text,length);
+    QString utf16Text = _decoder->toUnicode(text,length);
+    std::wstring unicodeText = utf16Text.toStdWString();
 
     //send characters to terminal emulator
-    for (int i=0;i<unicodeText.length();i++)
-        receiveChar(unicodeText[i].unicode());
+    for (size_t i=0;i<unicodeText.length();i++)
+        receiveChar(unicodeText[i]);
 
     //look for z-modem indicator
     //-- someone who understands more about z-modems that I do may be able to move

--- a/lib/Emulation.cpp
+++ b/lib/Emulation.cpp
@@ -239,6 +239,11 @@ void Emulation::receiveData(const char* text, int length)
 
     bufferedUpdate();
 
+    /* XXX: the following code involves encoding & decoding of "UTF-16
+     * surrogate pairs", which does not work with characters higher than
+     * U+10FFFF
+     * https://unicodebook.readthedocs.io/unicode_encodings.html#surrogates
+     */
     QString utf16Text = _decoder->toUnicode(text,length);
     std::wstring unicodeText = utf16Text.toStdWString();
 

--- a/lib/Emulation.h
+++ b/lib/Emulation.h
@@ -452,7 +452,7 @@ protected:
    * Processes an incoming character.  See receiveData()
    * @p ch A unicode character code.
    */
-  virtual void receiveChar(int ch);
+  virtual void receiveChar(wchar_t ch);
 
   /**
    * Sets the active screen.  The terminal has two screens, primary and alternate.

--- a/lib/Filter.cpp
+++ b/lib/Filter.cpp
@@ -224,7 +224,7 @@ void Filter::getLineColumn(int position , int& startLine , int& startColumn)
         if ( _linePositions->value(i) <= position && position < nextLine )
         {
             startLine = i;
-            startColumn = string_width(buffer()->mid(_linePositions->value(i),position - _linePositions->value(i)));
+            startColumn = string_width(buffer()->mid(_linePositions->value(i),position - _linePositions->value(i)).toStdWString());
             return;
         }
     }

--- a/lib/Screen.cpp
+++ b/lib/Screen.cpp
@@ -644,7 +644,7 @@ void Screen::checkSelection(int from, int to)
         clearSelection();
 }
 
-void Screen::displayCharacter(unsigned short c)
+void Screen::displayCharacter(wchar_t c)
 {
     // Note that VT100 does wrapping BEFORE putting the character.
     // This has impact on the assumption of valid cursor positions.

--- a/lib/Screen.h
+++ b/lib/Screen.h
@@ -346,7 +346,7 @@ public:
      * is inserted at the current cursor position, otherwise it will replace the
      * character already at the current cursor position.
      */
-    void displayCharacter(unsigned short c);
+    void displayCharacter(wchar_t c);
 
     // Do composition with last shown character FIXME: Not implemented yet for KDE 4
     void compose(const QString& compose);

--- a/lib/TerminalCharacterDecoder.h
+++ b/lib/TerminalCharacterDecoder.h
@@ -133,8 +133,8 @@ public:
     virtual void end();
 
 private:
-    void openSpan(QString& text , const QString& style);
-    void closeSpan(QString& text);
+    void openSpan(std::wstring& text , const QString& style);
+    void closeSpan(std::wstring& text);
 
     QTextStream* _output;
     const ColorEntry* _colorTable;

--- a/lib/TerminalDisplay.h
+++ b/lib/TerminalDisplay.h
@@ -633,7 +633,7 @@ private:
     // draws a section of text, all the text in this section
     // has a common color and style
     void drawTextFragment(QPainter& painter, const QRect& rect,
-                          const QString& text, const Character* style);
+                          const std::wstring& text, const Character* style);
     // draws the background for a text fragment
     // if useOpacitySetting is true then the color's alpha value will be set to
     // the display's transparency (set with setOpacity()), otherwise the background
@@ -644,11 +644,11 @@ private:
     void drawCursor(QPainter& painter, const QRect& rect , const QColor& foregroundColor,
                                        const QColor& backgroundColor , bool& invertColors);
     // draws the characters or line graphics in a text fragment
-    void drawCharacters(QPainter& painter, const QRect& rect,  const QString& text,
+    void drawCharacters(QPainter& painter, const QRect& rect,  const std::wstring& text,
                                            const Character* style, bool invertCharacterColor);
     // draws a string of line graphics
     void drawLineCharString(QPainter& painter, int x, int y,
-                            const QString& str, const Character* attributes);
+                            const std::wstring& str, const Character* attributes);
 
     // draws the preedit string for input methods
     void drawInputMethodPreeditString(QPainter& painter , const QRect& rect);
@@ -811,7 +811,7 @@ private:
 
     struct InputMethodData
     {
-        QString preeditString;
+        std::wstring preeditString;
         QRect previousPreeditRect;
     };
     InputMethodData _inputMethodData;

--- a/lib/Vt102Emulation.cpp
+++ b/lib/Vt102Emulation.cpp
@@ -198,7 +198,7 @@ void Vt102Emulation::addArgument()
   argv[argc] = 0;
 }
 
-void Vt102Emulation::addToCurrentToken(int cc)
+void Vt102Emulation::addToCurrentToken(wchar_t cc)
 {
   tokenBuffer[tokenBufferPos] = cc;
   tokenBufferPos = qMin(tokenBufferPos+1,MAX_TOKEN_LENGTH-1);
@@ -277,7 +277,7 @@ void Vt102Emulation::initTokenizer()
 #define DEL 127
 
 // process an incoming unicode character
-void Vt102Emulation::receiveChar(int cc)
+void Vt102Emulation::receiveChar(wchar_t cc)
 {
   if (cc == DEL)
     return; //VT100: ignore.
@@ -299,7 +299,7 @@ void Vt102Emulation::receiveChar(int cc)
   // advance the state
   addToCurrentToken(cc);
 
-  int* s = tokenBuffer;
+  wchar_t* s = tokenBuffer;
   int  p = tokenBufferPos;
 
   if (getMode(MODE_Ansi))
@@ -441,7 +441,7 @@ void Vt102Emulation::updateTitle()
    about this mapping.
 */
 
-void Vt102Emulation::processToken(int token, int p, int q)
+void Vt102Emulation::processToken(int token, wchar_t p, int q)
 {
   switch (token)
   {
@@ -1125,7 +1125,7 @@ void Vt102Emulation::sendKeyEvent( QKeyEvent* event )
 
 // Apply current character map.
 
-unsigned short Vt102Emulation::applyCharset(unsigned short c)
+wchar_t Vt102Emulation::applyCharset(wchar_t c)
 {
   if (CHARSET.graphic && 0x5f <= c && c <= 0x7e) return vt100_graphics[c-0x5f];
   if (CHARSET.pound && c == '#' ) return 0xa3; //This mode is obsolete
@@ -1336,7 +1336,7 @@ char Vt102Emulation::eraseChar() const
 }
 
 // print contents of the scan buffer
-static void hexdump(int* s, int len)
+static void hexdump(wchar_t* s, int len)
 { int i;
   for (i = 0; i < len; i++)
   {

--- a/lib/Vt102Emulation.h
+++ b/lib/Vt102Emulation.h
@@ -102,7 +102,7 @@ protected:
   // reimplemented from Emulation
   virtual void setMode(int mode);
   virtual void resetMode(int mode);
-  virtual void receiveChar(int cc);
+  virtual void receiveChar(wchar_t cc);
 
 private slots:
   //causes changeTitle() to be emitted for each (int,QString) pair in pendingTitleUpdates
@@ -110,7 +110,7 @@ private slots:
   void updateTitle();
 
 private:
-  unsigned short applyCharset(unsigned short c);
+  wchar_t applyCharset(wchar_t c);
   void setCharset(int n, int cs);
   void useCharset(int n);
   void setAndUseCharset(int n, int cs);
@@ -134,8 +134,8 @@ private:
 
   void resetTokenizer();
   #define MAX_TOKEN_LENGTH 256 // Max length of tokens (e.g. window title)
-  void addToCurrentToken(int cc);
-  int tokenBuffer[MAX_TOKEN_LENGTH]; //FIXME: overflow?
+  void addToCurrentToken(wchar_t cc);
+  wchar_t tokenBuffer[MAX_TOKEN_LENGTH]; //FIXME: overflow?
   int tokenBufferPos;
 #define MAXARGS 15
   void addDigit(int dig);
@@ -151,7 +151,7 @@ private:
 
   void reportDecodingError();
 
-  void processToken(int code, int p, int q);
+  void processToken(int code, wchar_t p, int q);
   void processWindowAttributeChange();
   void requestWindowAttribute(int);
 

--- a/lib/konsole_wcwidth.cpp
+++ b/lib/konsole_wcwidth.cpp
@@ -33,10 +33,9 @@ int konsole_wcwidth(wchar_t ucs)
 }
 
 // single byte char: +1, multi byte char: +2
-int string_width( const QString & txt )
+int string_width( const std::wstring & wstr )
 {
     int w = 0;
-    std::wstring wstr = txt.toStdWString();
     for ( size_t i = 0; i < wstr.length(); ++i ) {
         w += konsole_wcwidth( wstr[ i ] );
     }

--- a/lib/konsole_wcwidth.h
+++ b/lib/konsole_wcwidth.h
@@ -10,11 +10,11 @@
 #ifndef _KONSOLE_WCWIDTH_H_
 #define _KONSOLE_WCWIDTH_H_
 
-// Qt
-class QString;
+// Standard
+#include <string>
 
 int konsole_wcwidth(wchar_t ucs);
 
-int string_width( const QString & txt );
+int string_width( const std::wstring & wstr );
 
 #endif


### PR DESCRIPTION
Note: this PR depends on #94

In Qt, `QString` is a string of 16-bit charcters. As a result, it cannot handle non-BMP unicode characters correctly. For example, if I copy/paste `𝕐` into the terminal, and move the cursor with the left key, the terminal gets corrupted.

To fix it, I replace `QString` and `QChar`/`quint16` with `std::wstring` and `wchar_t`. With such a change non-BMP characters can be handled correctly in QTerminal.

There are two place I didn't change:
- Handling of character sequences. `RE_EXTENDED_CHAR` is defined in `lib/Character.h`, while it's never assigned to a `Character` in QTerminal. I'm not sure what it's used for, so I left it untouched.
- The filtering system, especially `Filter`, `TerminalCharacterDecoder` and their derived classes. I'm not sure what's their function, either.
