### PR TITLE
Preparations for context menu actions on URLs

### DIFF
--- a/lib/Filter.cpp
+++ b/lib/Filter.cpp
@@ -403,7 +403,7 @@ RegExpFilter::HotSpot* UrlFilter::newHotSpot(int startLine,int startColumn,int e
 {
     HotSpot *spot = new UrlFilter::HotSpot(startLine,startColumn,
                                                endLine,endColumn);
-    connect(spot->getUrlObject(), SIGNAL(activated(QUrl)), this, SIGNAL(activated(QUrl)));
+    connect(spot->getUrlObject(), &FilterObject::activated, this, &UrlFilter::activated);
     return spot;
 }
 
@@ -438,7 +438,7 @@ void UrlFilter::HotSpot::activate(const QString& actionName)
         return;
     }
 
-    if ( actionName.isEmpty() || actionName == "open-action" )
+    if ( actionName.isEmpty() || actionName == "open-action" || actionName == "click-action" )
     {
         if ( kind == StandardUrl )
         {
@@ -454,7 +454,7 @@ void UrlFilter::HotSpot::activate(const QString& actionName)
             url.prepend("mailto:");
         }
 
-        _urlObject->emitActivated(url);
+        _urlObject->emitActivated(url, actionName != "click-action");
     }
 }
 
@@ -485,12 +485,12 @@ UrlFilter::HotSpot::~HotSpot()
     delete _urlObject;
 }
 
-void FilterObject::emitActivated(const QUrl& url)
+void FilterObject::emitActivated(const QUrl& url, bool fromContextMenu)
 {
-    emit activated(url);
+    emit activated(url, fromContextMenu);
 }
 
-void FilterObject::activated()
+void FilterObject::activate()
 {
     _filter->activate(sender()->objectName());
 }
@@ -528,8 +528,8 @@ QList<QAction*> UrlFilter::HotSpot::actions()
     openAction->setObjectName( QLatin1String("open-action" ));
     copyAction->setObjectName( QLatin1String("copy-action" ));
 
-    QObject::connect( openAction , SIGNAL(triggered()) , _urlObject , SLOT(activated()) );
-    QObject::connect( copyAction , SIGNAL(triggered()) , _urlObject , SLOT(activated()) );
+    QObject::connect( openAction , &QAction::triggered , _urlObject , &FilterObject::activate );
+    QObject::connect( copyAction , &QAction::triggered , _urlObject , &FilterObject::activate );
 
     list << openAction;
     list << copyAction;

--- a/lib/Filter.h
+++ b/lib/Filter.h
@@ -289,7 +289,7 @@ private:
     // combined OR of FullUrlRegExp and EmailAddressRegExp
     static const QRegExp CompleteUrlRegExp;
 signals:
-    void activated(const QUrl& url);
+    void activated(const QUrl& url, bool fromContextMenu);
 };
 
 class FilterObject : public QObject
@@ -298,13 +298,13 @@ class FilterObject : public QObject
 public:
     FilterObject(Filter::HotSpot* filter) : _filter(filter) {}
 
-    void emitActivated(const QUrl& url);
-private slots:
-    void activated();
+    void emitActivated(const QUrl& url, bool fromContextMenu);
+public slots:
+    void activate();
 private:
     Filter::HotSpot* _filter;
 signals:
-    void activated(const QUrl& url);
+    void activated(const QUrl& url, bool fromContextMenu);
 };
 
 /**

--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -1791,7 +1791,7 @@ void TerminalDisplay::mousePressEvent(QMouseEvent* ev)
 
       Filter::HotSpot *spot = _filterChain->hotSpotAt(charLine, charColumn);
       if (spot && spot->type() == Filter::HotSpot::Link)
-          spot->activate("open-action");
+          spot->activate("click-action");
     }
   }
   else if ( ev->button() == Qt::MidButton )

--- a/lib/qtermwidget.cpp
+++ b/lib/qtermwidget.cpp
@@ -258,7 +258,7 @@ void QTermWidget::init(int startnow)
 
     // That's OK, FilterChain's dtor takes care of UrlFilter.
     UrlFilter *urlFilter = new UrlFilter();
-    connect(urlFilter, SIGNAL(activated(QUrl)), this, SIGNAL(urlActivated(QUrl)));
+    connect(urlFilter, &UrlFilter::activated, this, &QTermWidget::urlActivated);
     m_impl->m_terminalDisplay->filterChain()->addFilter(urlFilter);
 
     m_searchBar = new SearchBar(this);
@@ -641,6 +641,11 @@ Filter::HotSpot* QTermWidget::getHotSpotAt(const QPoint &pos) const
 Filter::HotSpot* QTermWidget::getHotSpotAt(int row, int column) const
 {
     return m_impl->m_terminalDisplay->filterChain()->hotSpotAt(row, column);
+}
+
+QList<QAction*> QTermWidget::filterActions(const QPoint& position)
+{
+    return m_impl->m_terminalDisplay->filterActions(position);
 }
 
 int QTermWidget::getPtySlaveFd() const

--- a/lib/qtermwidget.h
+++ b/lib/qtermwidget.h
@@ -192,6 +192,11 @@ public:
      */
     Filter::HotSpot* getHotSpotAt(int row, int column) const;
 
+    /*
+     * Proxy for TerminalDisplay::filterActions
+     * */
+    QList<QAction*> filterActions(const QPoint& position);
+
     /**
      * Returns a pty slave file descriptor.
      * This can be used for display and control
@@ -220,7 +225,7 @@ signals:
 
     void termKeyPressed(QKeyEvent *);
 
-    void urlActivated(const QUrl&);
+    void urlActivated(const QUrl&, bool fromContextMenu);
 
     void bell(const QString& message);
 


### PR DESCRIPTION
Prerequisites for https://github.com/lxde/qterminal/issues/152
1. Define click-action so that QTermWidget clients can tell clicking
   from context menu actions
2. Expose filterActions
