### PR TITLE
Drop the ancient wcwidth impl. and use utf8proc if possible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,16 @@ add_definitions(-Wall)
 set(QTERMWIDGET_LIBRARY_NAME qtermwidget5)
 include(qtermwidget5_use)
 
+option(USE_UTF8PROC "Use libutf8proc for better Unicode support. Default OFF" OFF)
+
+if(USE_UTF8PROC)
+    find_package(Utf8Proc)
+endif()
+
+if (UTF8PROC_FOUND)
+    add_definitions(-DHAVE_UTF8PROC)
+    include_directories("${UTF8PROC_INCLUDE_DIRS}")
+endif()
 
 # main library
 
@@ -129,6 +139,9 @@ set_target_properties( ${QTERMWIDGET_LIBRARY_NAME} PROPERTIES
                        SOVERSION ${QTERMWIDGET_VERSION_MAJOR}
                        VERSION ${QTERMWIDGET_VERSION}
                      )
+if (UTF8PROC_FOUND)
+    target_link_libraries(${QTERMWIDGET_LIBRARY_NAME} ${UTF8PROC_LIBRARIES})
+endif()
 if(APPLE)
     set (CMAKE_SKIP_RPATH 1)
     # this is a must to load the lib correctly

--- a/cmake/FindUtf8Proc.cmake
+++ b/cmake/FindUtf8Proc.cmake
@@ -1,0 +1,59 @@
+#.rst:
+# FindUtf8Proc
+# --------
+#
+# Find utf8proc
+#
+# Find the UTF-8 processing library
+#
+# ::
+#
+#   This module defines the following variables:
+#      UTF8PROC_FOUND       - True if UTF8PROC_INCLUDE_DIR & UTF8PROC_LIBRARY are found
+#      UTF8PROC_LIBRARIES   - Set when UTF8PROC_LIBRARY is found
+#      UTF8PROC_INCLUDE_DIRS - Set when UTF8PROC_INCLUDE_DIR is found
+#
+#
+#
+# ::
+#
+#      UTF8PROC_INCLUDE_DIR - where to find utf8proc.h
+#      UTF8PROC_LIBRARY     - the utf8proc library
+
+#=============================================================================
+# This module is adapted from FindALSA.cmake. Below are the original license
+# header.
+#=============================================================================
+# Copyright 2009-2011 Kitware, Inc.
+# Copyright 2009-2011 Philip Lowman <philip@yhbt.com>
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+
+find_path(
+    UTF8PROC_INCLUDE_DIR NAMES utf8proc.h DOC "The utf8proc include directory"
+)
+
+find_library(
+    UTF8PROC_LIBRARY NAMES utf8proc DOC "The utf8proc library"
+)
+
+# handle the QUIETLY and REQUIRED arguments and set UTF8PROC_FOUND to TRUE if
+# all listed variables are TRUE
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(
+    UTF8PROC
+    REQUIRED_VARS UTF8PROC_LIBRARY UTF8PROC_INCLUDE_DIR
+)
+
+if(UTF8PROC_FOUND)
+  set( UTF8PROC_LIBRARIES ${UTF8PROC_LIBRARY} )
+  set( UTF8PROC_INCLUDE_DIRS ${UTF8PROC_INCLUDE_DIR} )
+endif()
+
+mark_as_advanced(UTF8PROC_INCLUDE_DIR UTF8PROC_LIBRARY)

--- a/lib/konsole_wcwidth.cpp
+++ b/lib/konsole_wcwidth.cpp
@@ -9,218 +9,36 @@
 
 #include <QString>
 
+#ifdef HAVE_UTF8PROC
+#include <utf8proc.h>
+#else
+#include <cwchar>
+#endif
+
 #include "konsole_wcwidth.h"
 
-struct interval {
-    unsigned short first;
-    unsigned short last;
-};
-
-/* auxiliary function for binary search in interval table */
-static int bisearch(quint16 ucs, const struct interval * table, int max)
+int konsole_wcwidth(wchar_t ucs)
 {
-    int min = 0;
-    int mid;
-
-    if (ucs < table[0].first || ucs > table[max].last) {
-        return 0;
+#ifdef HAVE_UTF8PROC
+    utf8proc_category_t cat = utf8proc_category( ucs );
+    if (cat == UTF8PROC_CATEGORY_CO) {
+        // Co: Private use area. libutf8proc makes them zero width, while tmux
+        // assumes them to be width 1, and glibc's default width is also 1
+        return 1;
     }
-    while (max >= min) {
-        mid = (min + max) / 2;
-        if (ucs > table[mid].last) {
-            min = mid + 1;
-        } else if (ucs < table[mid].first) {
-            max = mid - 1;
-        } else {
-            return 1;
-        }
-    }
-
-    return 0;
-}
-
-
-/* The following functions define the column width of an ISO 10646
- * character as follows:
- *
- *    - The null character (U+0000) has a column width of 0.
- *
- *    - Other C0/C1 control characters and DEL will lead to a return
- *      value of -1.
- *
- *    - Non-spacing and enclosing combining characters (general
- *      category code Mn or Me in the Unicode database) have a
- *      column width of 0.
- *
- *    - Other format characters (general category code Cf in the Unicode
- *      database) and ZERO WIDTH SPACE (U+200B) have a column width of 0.
- *
- *    - Hangul Jamo medial vowels and final consonants (U+1160-U+11FF)
- *      have a column width of 0.
- *
- *    - Spacing characters in the East Asian Wide (W) or East Asian
- *      FullWidth (F) category as defined in Unicode Technical
- *      Report #11 have a column width of 2.
- *
- *    - All remaining characters (including all printable
- *      ISO 8859-1 and WGL4 characters, Unicode control characters,
- *      etc.) have a column width of 1.
- *
- * This implementation assumes that quint16 characters are encoded
- * in ISO 10646.
- */
-
-int konsole_wcwidth(quint16 ucs)
-{
-    /* sorted list of non-overlapping intervals of non-spacing characters */
-    static const struct interval combining[] = {
-        { 0x0300, 0x034E }, { 0x0360, 0x0362 }, { 0x0483, 0x0486 },
-        { 0x0488, 0x0489 }, { 0x0591, 0x05A1 }, { 0x05A3, 0x05B9 },
-        { 0x05BB, 0x05BD }, { 0x05BF, 0x05BF }, { 0x05C1, 0x05C2 },
-        { 0x05C4, 0x05C4 }, { 0x064B, 0x0655 }, { 0x0670, 0x0670 },
-        { 0x06D6, 0x06E4 }, { 0x06E7, 0x06E8 }, { 0x06EA, 0x06ED },
-        { 0x070F, 0x070F }, { 0x0711, 0x0711 }, { 0x0730, 0x074A },
-        { 0x07A6, 0x07B0 }, { 0x0901, 0x0902 }, { 0x093C, 0x093C },
-        { 0x0941, 0x0948 }, { 0x094D, 0x094D }, { 0x0951, 0x0954 },
-        { 0x0962, 0x0963 }, { 0x0981, 0x0981 }, { 0x09BC, 0x09BC },
-        { 0x09C1, 0x09C4 }, { 0x09CD, 0x09CD }, { 0x09E2, 0x09E3 },
-        { 0x0A02, 0x0A02 }, { 0x0A3C, 0x0A3C }, { 0x0A41, 0x0A42 },
-        { 0x0A47, 0x0A48 }, { 0x0A4B, 0x0A4D }, { 0x0A70, 0x0A71 },
-        { 0x0A81, 0x0A82 }, { 0x0ABC, 0x0ABC }, { 0x0AC1, 0x0AC5 },
-        { 0x0AC7, 0x0AC8 }, { 0x0ACD, 0x0ACD }, { 0x0B01, 0x0B01 },
-        { 0x0B3C, 0x0B3C }, { 0x0B3F, 0x0B3F }, { 0x0B41, 0x0B43 },
-        { 0x0B4D, 0x0B4D }, { 0x0B56, 0x0B56 }, { 0x0B82, 0x0B82 },
-        { 0x0BC0, 0x0BC0 }, { 0x0BCD, 0x0BCD }, { 0x0C3E, 0x0C40 },
-        { 0x0C46, 0x0C48 }, { 0x0C4A, 0x0C4D }, { 0x0C55, 0x0C56 },
-        { 0x0CBF, 0x0CBF }, { 0x0CC6, 0x0CC6 }, { 0x0CCC, 0x0CCD },
-        { 0x0D41, 0x0D43 }, { 0x0D4D, 0x0D4D }, { 0x0DCA, 0x0DCA },
-        { 0x0DD2, 0x0DD4 }, { 0x0DD6, 0x0DD6 }, { 0x0E31, 0x0E31 },
-        { 0x0E34, 0x0E3A }, { 0x0E47, 0x0E4E }, { 0x0EB1, 0x0EB1 },
-        { 0x0EB4, 0x0EB9 }, { 0x0EBB, 0x0EBC }, { 0x0EC8, 0x0ECD },
-        { 0x0F18, 0x0F19 }, { 0x0F35, 0x0F35 }, { 0x0F37, 0x0F37 },
-        { 0x0F39, 0x0F39 }, { 0x0F71, 0x0F7E }, { 0x0F80, 0x0F84 },
-        { 0x0F86, 0x0F87 }, { 0x0F90, 0x0F97 }, { 0x0F99, 0x0FBC },
-        { 0x0FC6, 0x0FC6 }, { 0x102D, 0x1030 }, { 0x1032, 0x1032 },
-        { 0x1036, 0x1037 }, { 0x1039, 0x1039 }, { 0x1058, 0x1059 },
-        { 0x1160, 0x11FF }, { 0x17B7, 0x17BD }, { 0x17C6, 0x17C6 },
-        { 0x17C9, 0x17D3 }, { 0x180B, 0x180E }, { 0x18A9, 0x18A9 },
-        { 0x200B, 0x200F }, { 0x202A, 0x202E }, { 0x206A, 0x206F },
-        { 0x20D0, 0x20E3 }, { 0x302A, 0x302F }, { 0x3099, 0x309A },
-        { 0xFB1E, 0xFB1E }, { 0xFE20, 0xFE23 }, { 0xFEFF, 0xFEFF },
-        { 0xFFF9, 0xFFFB }
-    };
-
-    /* test for 8-bit control characters */
-    if (ucs == 0) {
-        return 0;
-    }
-    if (ucs < 32 || (ucs >= 0x7f && ucs < 0xa0)) {
-        return -1;
-    }
-
-    /* binary search in table of non-spacing characters */
-    if (bisearch(ucs, combining,
-                 sizeof(combining) / sizeof(struct interval) - 1)) {
-        return 0;
-    }
-
-    /* if we arrive here, ucs is not a combining or C0/C1 control character */
-
-    return 1 +
-           (ucs >= 0x1100 &&
-            (ucs <= 0x115f ||                    /* Hangul Jamo init. consonants */
-             (ucs >= 0x2e80 && ucs <= 0xa4cf && (ucs & ~0x0011) != 0x300a &&
-              ucs != 0x303f) ||                  /* CJK ... Yi */
-             (ucs >= 0xac00 && ucs <= 0xd7a3) || /* Hangul Syllables */
-             (ucs >= 0xf900 && ucs <= 0xfaff) || /* CJK Compatibility Ideographs */
-             (ucs >= 0xfe30 && ucs <= 0xfe6f) || /* CJK Compatibility Forms */
-             (ucs >= 0xff00 && ucs <= 0xff5f) || /* Fullwidth Forms */
-             (ucs >= 0xffe0 && ucs <= 0xffe6) /* do not compare UINT16 with 0x20000 ||
-      (ucs >= 0x20000 && ucs <= 0x2ffff) */));
-}
-
-#if 0
-/*
- * The following function is the same as konsole_wcwidth(), except that
- * spacing characters in the East Asian Ambiguous (A) category as
- * defined in Unicode Technical Report #11 have a column width of 2.
- * This experimental variant might be useful for users of CJK legacy
- * encodings who want to migrate to UCS. It is not otherwise
- * recommended for general use.
- */
-int konsole_wcwidth_cjk(quint16 ucs)
-{
-    /* sorted list of non-overlapping intervals of East Asian Ambiguous
-     * characters */
-    static const struct interval ambiguous[] = {
-        { 0x00A1, 0x00A1 }, { 0x00A4, 0x00A4 }, { 0x00A7, 0x00A8 },
-        { 0x00AA, 0x00AA }, { 0x00AD, 0x00AD }, { 0x00B0, 0x00B4 },
-        { 0x00B6, 0x00BA }, { 0x00BC, 0x00BF }, { 0x00C6, 0x00C6 },
-        { 0x00D0, 0x00D0 }, { 0x00D7, 0x00D8 }, { 0x00DE, 0x00E1 },
-        { 0x00E6, 0x00E6 }, { 0x00E8, 0x00EA }, { 0x00EC, 0x00ED },
-        { 0x00F0, 0x00F0 }, { 0x00F2, 0x00F3 }, { 0x00F7, 0x00FA },
-        { 0x00FC, 0x00FC }, { 0x00FE, 0x00FE }, { 0x0101, 0x0101 },
-        { 0x0111, 0x0111 }, { 0x0113, 0x0113 }, { 0x011B, 0x011B },
-        { 0x0126, 0x0127 }, { 0x012B, 0x012B }, { 0x0131, 0x0133 },
-        { 0x0138, 0x0138 }, { 0x013F, 0x0142 }, { 0x0144, 0x0144 },
-        { 0x0148, 0x014A }, { 0x014D, 0x014D }, { 0x0152, 0x0153 },
-        { 0x0166, 0x0167 }, { 0x016B, 0x016B }, { 0x01CE, 0x01CE },
-        { 0x01D0, 0x01D0 }, { 0x01D2, 0x01D2 }, { 0x01D4, 0x01D4 },
-        { 0x01D6, 0x01D6 }, { 0x01D8, 0x01D8 }, { 0x01DA, 0x01DA },
-        { 0x01DC, 0x01DC }, { 0x0251, 0x0251 }, { 0x0261, 0x0261 },
-        { 0x02C7, 0x02C7 }, { 0x02C9, 0x02CB }, { 0x02CD, 0x02CD },
-        { 0x02D0, 0x02D0 }, { 0x02D8, 0x02DB }, { 0x02DD, 0x02DD },
-        { 0x0391, 0x03A1 }, { 0x03A3, 0x03A9 }, { 0x03B1, 0x03C1 },
-        { 0x03C3, 0x03C9 }, { 0x0401, 0x0401 }, { 0x0410, 0x044F },
-        { 0x0451, 0x0451 }, { 0x2010, 0x2010 }, { 0x2013, 0x2016 },
-        { 0x2018, 0x2019 }, { 0x201C, 0x201D }, { 0x2020, 0x2021 },
-        { 0x2025, 0x2027 }, { 0x2030, 0x2030 }, { 0x2032, 0x2033 },
-        { 0x2035, 0x2035 }, { 0x203B, 0x203B }, { 0x2074, 0x2074 },
-        { 0x207F, 0x207F }, { 0x2081, 0x2084 }, { 0x20AC, 0x20AC },
-        { 0x2103, 0x2103 }, { 0x2105, 0x2105 }, { 0x2109, 0x2109 },
-        { 0x2113, 0x2113 }, { 0x2121, 0x2122 }, { 0x2126, 0x2126 },
-        { 0x212B, 0x212B }, { 0x2154, 0x2155 }, { 0x215B, 0x215B },
-        { 0x215E, 0x215E }, { 0x2160, 0x216B }, { 0x2170, 0x2179 },
-        { 0x2190, 0x2199 }, { 0x21D2, 0x21D2 }, { 0x21D4, 0x21D4 },
-        { 0x2200, 0x2200 }, { 0x2202, 0x2203 }, { 0x2207, 0x2208 },
-        { 0x220B, 0x220B }, { 0x220F, 0x220F }, { 0x2211, 0x2211 },
-        { 0x2215, 0x2215 }, { 0x221A, 0x221A }, { 0x221D, 0x2220 },
-        { 0x2223, 0x2223 }, { 0x2225, 0x2225 }, { 0x2227, 0x222C },
-        { 0x222E, 0x222E }, { 0x2234, 0x2237 }, { 0x223C, 0x223D },
-        { 0x2248, 0x2248 }, { 0x224C, 0x224C }, { 0x2252, 0x2252 },
-        { 0x2260, 0x2261 }, { 0x2264, 0x2267 }, { 0x226A, 0x226B },
-        { 0x226E, 0x226F }, { 0x2282, 0x2283 }, { 0x2286, 0x2287 },
-        { 0x2295, 0x2295 }, { 0x2299, 0x2299 }, { 0x22A5, 0x22A5 },
-        { 0x22BF, 0x22BF }, { 0x2312, 0x2312 }, { 0x2460, 0x24BF },
-        { 0x24D0, 0x24E9 }, { 0x2500, 0x254B }, { 0x2550, 0x2574 },
-        { 0x2580, 0x258F }, { 0x2592, 0x2595 }, { 0x25A0, 0x25A1 },
-        { 0x25A3, 0x25A9 }, { 0x25B2, 0x25B3 }, { 0x25B6, 0x25B7 },
-        { 0x25BC, 0x25BD }, { 0x25C0, 0x25C1 }, { 0x25C6, 0x25C8 },
-        { 0x25CB, 0x25CB }, { 0x25CE, 0x25D1 }, { 0x25E2, 0x25E5 },
-        { 0x25EF, 0x25EF }, { 0x2605, 0x2606 }, { 0x2609, 0x2609 },
-        { 0x260E, 0x260F }, { 0x261C, 0x261C }, { 0x261E, 0x261E },
-        { 0x2640, 0x2640 }, { 0x2642, 0x2642 }, { 0x2660, 0x2661 },
-        { 0x2663, 0x2665 }, { 0x2667, 0x266A }, { 0x266C, 0x266D },
-        { 0x266F, 0x266F }, { 0x300A, 0x300B }, { 0x301A, 0x301B },
-        { 0xE000, 0xF8FF }, { 0xFFFD, 0xFFFD }
-    };
-
-    /* binary search in table of non-spacing characters */
-    if (bisearch(ucs, ambiguous,
-                 sizeof(ambiguous) / sizeof(struct interval) - 1)) {
-        return 2;
-    }
-
-    return konsole_wcwidth(ucs);
-}
+    return utf8proc_charwidth( ucs );
+#else
+    return wcwidth( ucs );
 #endif
+}
 
 // single byte char: +1, multi byte char: +2
 int string_width( const QString & txt )
 {
     int w = 0;
-    for ( int i = 0; i < txt.length(); ++i ) {
-        w += konsole_wcwidth( txt[ i ].unicode() );
+    std::wstring wstr = txt.toStdWString();
+    for ( size_t i = 0; i < wstr.length(); ++i ) {
+        w += konsole_wcwidth( wstr[ i ] );
     }
     return w;
 }

--- a/lib/konsole_wcwidth.h
+++ b/lib/konsole_wcwidth.h
@@ -11,14 +11,9 @@
 #define _KONSOLE_WCWIDTH_H_
 
 // Qt
-#include <QtGlobal>
-
 class QString;
 
-int konsole_wcwidth(quint16 ucs);
-#if 0
-int konsole_wcwidth_cjk(Q_UINT16 ucs);
-#endif
+int konsole_wcwidth(wchar_t ucs);
 
 int string_width( const QString & txt );
 


### PR DESCRIPTION
This PR supersedes #94

utf8proc is also a C library that handles Unicode character width. In comparsion with termux/wcwidth, https://github.com/JuliaLang/utf8proc has a few advantages:

* Much better maintained
* Used in tmux (https://github.com/tmux/tmux/pull/524), Julia and netsurf, which uses their own [fork](http://git.netsurf-browser.org/libutf8proc.git/). Its stability is convincing
* No need to keep a copy in QTermWidget

There are disadvantages too:
* Packagers need to install utf8proc first if they want the latest Unicode 9.0.0

Use of utf8proc is not mandatory. I provide a cmake option for users/packagers to choose from. If QTermWidget is built with glibc's wcwidth(), it works with other applications that is doing so. For example, Python's REPL, which uses GNU readline, depends on glibc's version. As of writing, the latest glibc [uses Unicode 8.0.0](https://sourceware.org/git/?p=glibc.git;a=blob;f=localedata/unicode-gen/EastAsianWidth.txt;h=b72970e17138719a3d55771ed101f35b62eca6dd;hb=HEAD). On the other hand, if QTermWidget is linked against utf8proc, it's compatible with other terminals that use Unicode 9.0.0, like [Gnome/VTE](https://bugzilla.gnome.org/show_bug.cgi?id=771591).