### PR TITLE
Exposes sessions autoClose property to QTermWidget

### DIFF
--- a/lib/qtermwidget.cpp
+++ b/lib/qtermwidget.cpp
@@ -688,3 +688,8 @@ bool QTermWidget::isTitleChanged() const
 {
     return m_impl->m_session->isTitleChanged();
 }
+
+void QTermWidget::setAutoClose(bool autoClose)
+{
+    m_impl->m_session->setAutoClose(autoClose);
+}

--- a/lib/qtermwidget.h
+++ b/lib/qtermwidget.h
@@ -211,6 +211,13 @@ public:
      */
     void setKeyboardCursorShape(KeyboardCursorShape shape);
 
+
+    /**
+     * Automatically close the terminal session after the shell process exits or
+     * keep it running.
+     */
+    void setAutoClose(bool);
+
     QString title() const;
     QString icon() const;
 


### PR DESCRIPTION
I made this change to QTermWidget because I need to set autoClose to false in a project of mine. It might be useful to other users.