### PR TITLE
Profile changed signal

### DIFF
--- a/lib/qtermwidget.cpp
+++ b/lib/qtermwidget.cpp
@@ -276,7 +276,7 @@ void QTermWidget::init(int startnow)
 
     connect(m_impl->m_session, SIGNAL(activity()), this, SIGNAL(activity()));
     connect(m_impl->m_session, SIGNAL(silence()), this, SIGNAL(silence()));
-
+    connect(m_impl->m_session, &Session::profileChangeCommandReceived, this, &QTermWidget::profileChanged);
     connect(m_impl->m_session, &Session::receivedData, this, &QTermWidget::receivedData);
 
     // That's OK, FilterChain's dtor takes care of UrlFilter.

--- a/lib/qtermwidget.h
+++ b/lib/qtermwidget.h
@@ -249,6 +249,8 @@ signals:
      */
     void sendData(const char *,int);
 
+    void profileChanged(const QString & profile);
+
     void titleChanged();
 
     /**

--- a/pyqt/qtermwidget.sip
+++ b/pyqt/qtermwidget.sip
@@ -83,6 +83,7 @@ signals:
     void sendData(const char *,int);
     void titleChanged();
     void receivedData(const QString &text);
+    void profileChanged(const QString & profile);
 public slots:
     void copyClipboard();
     void pasteClipboard();


### PR DESCRIPTION
This commit allows the consumer of qtermwidget to capture the
profileChanged signal and receive all of the settings change escape
codes

Fixes #110 and needs #108 to be merged first. If #108 isn't going to be merged, this can be merged independently with some minor modifications