### PR TITLE
Fix memory leak in hotspot (URLs & emails) detection

### DIFF
--- a/lib/Filter.cpp
+++ b/lib/Filter.cpp
@@ -26,6 +26,7 @@
 // Qt
 #include <QAction>
 #include <QApplication>
+#include <QtAlgorithms>
 #include <QClipboard>
 #include <QString>
 #include <QTextStream>
@@ -194,6 +195,7 @@ Filter::~Filter()
 }
 void Filter::reset()
 {
+    qDeleteAll(_hotspotList);
     _hotspots.clear();
     _hotspotList.clear();
 }


### PR DESCRIPTION
May be it's another source of https://github.com/lxde/qterminal/issues/156

Whenever the terminal output changes, filters (URLs and emails) are processed and hotspots are generated with ```new``` in two ```newHotSpot``` functions in Filter.cpp. The list of hostspots are cleared when the terminal output is changed again but those hostspot objects are not ```delete```'d. Only the last series of hotspots gets deleted in ```Filter::~Filter()```.

Steps to reproduce the leak: Run ```echo http://127.0.0.1``` several times

Partial valgrind log:
```
==2274== 25,308 (48 direct, 25,260 indirect) bytes in 2 blocks are definitely lost in loss record 355 of 356
==2274==    at 0x4C2B58F: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==2274==    by 0x4E5913E: Konsole::UrlFilter::HotSpot::HotSpot(int, int, int, int) (Filter.cpp:412)
==2274==    by 0x4E59077: Konsole::UrlFilter::newHotSpot(int, int, int, int) (Filter.cpp:405)
==2274==    by 0x4E58F58: Konsole::RegExpFilter::process() (Filter.cpp:382)
==2274==    by 0x4E581A8: Konsole::FilterChain::process() (Filter.cpp:87)
==2274==    by 0x4E88987: Konsole::TerminalDisplay::processFilters() (TerminalDisplay.cpp:1040)
==2274==    by 0x4E8EE89: Konsole::TerminalDisplay::updateFilters() (TerminalDisplay.cpp:2335)
==2274==    by 0x4EA04D9: Konsole::TerminalDisplay::qt_static_metacall(QObject*, QMetaObject::Call, int, void**) (moc_TerminalDisplay.cpp:232)
==2274==    by 0x6CA8D48: QMetaObject::activate(QObject*, int, int, void**) (in /usr/lib/libQt5Core.so.5.8.0)
==2274==    by 0x4E9EC2F: Konsole::ScreenWindow::scrolled(int) (moc_ScreenWindow.cpp:166)
==2274==    by 0x4E7C9D4: Konsole::ScreenWindow::scrollTo(int) (ScreenWindow.cpp:232)
==2274==    by 0x4E8C388: Konsole::TerminalDisplay::scrollToEnd() (TerminalDisplay.cpp:1820)
```
After also applying https://github.com/lxde/qterminal/pull/306, the only leak left is in qdbus. I haven't identified the cause yet.
```
==2274== 6,720 (232 direct, 6,488 indirect) bytes in 1 blocks are definitely lost in loss record 344 of 356
==2274==    at 0x4C2CF35: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==2274==    by 0x10E3C99F: ??? (in /usr/lib/libdbus-1.so.3.14.10)
==2274==    by 0x10E46ACE: ??? (in /usr/lib/libdbus-1.so.3.14.10)
==2274==    by 0x10E46EF9: ??? (in /usr/lib/libdbus-1.so.3.14.10)
==2274==    by 0x10E3AD59: ??? (in /usr/lib/libdbus-1.so.3.14.10)
==2274==    by 0x10E25641: ??? (in /usr/lib/libdbus-1.so.3.14.10)
==2274==    by 0x10E20F4B: ??? (in /usr/lib/libdbus-1.so.3.14.10)
==2274==    by 0xE673F81: ??? (in /usr/lib/libQt5DBus.so.5.8.0)
==2274==    by 0x6CA9BA8: QObject::event(QEvent*) (in /usr/lib/libQt5Core.so.5.8.0)
==2274==    by 0x6C7D42A: QCoreApplication::notifyInternal2(QObject*, QEvent*) (in /usr/lib/libQt5Core.so.5.8.0)
==2274==    by 0x6C7FBCC: QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) (in /usr/lib/libQt5Core.so.5.8.0)
==2274==    by 0x6CD1C42: ??? (in /usr/lib/libQt5Core.so.5.8.0)
```