### PR TITLE
Allow the terminal display to be smaller than the size hint

### DIFF
--- a/lib/qtermwidget.cpp
+++ b/lib/qtermwidget.cpp
@@ -268,7 +268,6 @@ void QTermWidget::init(int startnow)
     }
 
     m_impl = new TermWidgetImpl(this);
-    m_impl->m_terminalDisplay->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
     m_layout->addWidget(m_impl->m_terminalDisplay);
 
     connect(m_impl->m_session, SIGNAL(bellRequest(QString)), m_impl->m_terminalDisplay, SLOT(bell(QString)));


### PR DESCRIPTION
Fixes https://github.com/lxde/qterminal/issues/288