### PR TITLE
Handle DECSCUSR signals

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,7 @@ set(UI
 # for distribution
 set(HDRS_DISTRIB
     lib/qtermwidget.h
+    lib/Emulation.h
     lib/Filter.h
 )
 

--- a/lib/Emulation.cpp
+++ b/lib/Emulation.cpp
@@ -70,6 +70,11 @@ Emulation::Emulation() :
            SLOT(usesMouseChanged(bool)));
   connect(this , SIGNAL(programBracketedPasteModeChanged(bool)) ,
            SLOT(bracketedPasteModeChanged(bool)));
+
+  connect(this, &Emulation::cursorChanged, [this] (KeyboardCursorShape cursorShape, bool blinkingCursorEnabled) {
+    emit titleChanged( 50, QString("CursorShape=%1;BlinkingCursorEnabled=%2")
+                               .arg(static_cast<int>(cursorShape)).arg(blinkingCursorEnabled) );
+  });
 }
 
 bool Emulation::programUsesMouse() const

--- a/lib/Emulation.h
+++ b/lib/Emulation.h
@@ -126,6 +126,26 @@ Q_OBJECT
 
 public:
 
+  /**
+   * This enum describes the available shapes for the keyboard cursor.
+   * See setKeyboardCursorShape()
+   */
+  enum class KeyboardCursorShape {
+      /** A rectangular block which covers the entire area of the cursor character. */
+      BlockCursor = 0,
+      /**
+       * A single flat line which occupies the space at the bottom of the cursor
+       * character's area.
+       */
+      UnderlineCursor = 1,
+      /**
+       * An cursor shaped like the capital letter 'I', similar to the IBeam
+       * cursor used in Qt/KDE text editors.
+       */
+      IBeamCursor = 2
+  };
+
+
    /** Constructs a new terminal emulation */
    Emulation();
   ~Emulation();
@@ -414,6 +434,15 @@ signals:
    * resume output.
    */
   void flowControlKeyPressed(bool suspendKeyPressed);
+
+  /**
+   * Emitted when the cursor shape or its blinking state is changed via
+   * DECSCUSR sequences.
+   *
+   * @param cursorShape One of 3 possible values in KeyboardCursorShape enum
+   * @param blinkingCursorEnabled Whether to enable blinking or not
+   */
+  void cursorChanged(KeyboardCursorShape cursorShape, bool blinkingCursorEnabled);
 
 protected:
   virtual void setMode(int mode) = 0;

--- a/lib/Session.cpp
+++ b/lib/Session.cpp
@@ -99,6 +99,8 @@ Session::Session(QObject* parent) :
             this, SLOT(onEmulationSizeChange(QSize)));
     connect(_emulation, SIGNAL(imageSizeChanged(int, int)),
             this, SLOT(onViewSizeChange(int, int)));
+    connect(_emulation, &Vt102Emulation::cursorChanged,
+            this, &Session::cursorChanged);
 
     //connect teletype to emulation backend
     _shellProcess->setUtf8Mode(_emulation->utf8());

--- a/lib/Session.h
+++ b/lib/Session.h
@@ -28,6 +28,7 @@
 #include <QStringList>
 #include <QWidget>
 
+#include "Emulation.h"
 #include "History.h"
 
 class KProcess;
@@ -476,6 +477,11 @@ signals:
      * @param enabled True if flow control is enabled or false otherwise.
      */
     void flowControlEnabledChanged(bool enabled);
+
+    /**
+     * Broker for Emulation::cursorChanged() signal
+     */
+    void cursorChanged(Emulation::KeyboardCursorShape cursorShape, bool blinkingCursorEnabled);
 
     void silence();
     void activity();

--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -334,7 +334,7 @@ TerminalDisplay::TerminalDisplay(QWidget *parent)
 ,_colorsInverted(false)
 ,_blendColor(qRgba(0,0,0,0xff))
 ,_filterChain(new TerminalImageFilterChain())
-,_cursorShape(QTermWidget::BlockCursor)
+,_cursorShape(Emulation::KeyboardCursorShape::BlockCursor)
 ,mMotionAfterPasting(NoMoveScreenWindow)
 {
   // terminal applications are not designed with Right-To-Left in mind,
@@ -739,7 +739,7 @@ void TerminalDisplay::drawCursor(QPainter& painter,
        else
            painter.setPen(foregroundColor);
 
-       if ( _cursorShape == QTermWidget::BlockCursor )
+       if ( _cursorShape == Emulation::KeyboardCursorShape::BlockCursor )
        {
             // draw the cursor outline, adjusting the area so that
             // it is draw entirely inside 'rect'
@@ -761,12 +761,12 @@ void TerminalDisplay::drawCursor(QPainter& painter,
                 }
             }
        }
-       else if ( _cursorShape == QTermWidget::UnderlineCursor )
+       else if ( _cursorShape == Emulation::KeyboardCursorShape::UnderlineCursor )
             painter.drawLine(cursorRect.left(),
                              cursorRect.bottom(),
                              cursorRect.right(),
                              cursorRect.bottom());
-       else if ( _cursorShape == QTermWidget::IBeamCursor )
+       else if ( _cursorShape == Emulation::KeyboardCursorShape::IBeamCursor )
             painter.drawLine(cursorRect.left(),
                              cursorRect.top(),
                              cursorRect.left(),

--- a/lib/Vt102Emulation.cpp
+++ b/lib/Vt102Emulation.cpp
@@ -642,13 +642,13 @@ void Vt102Emulation::processToken(int token, int p, int q)
     case TY_CSI_PS('x',   0) :      reportTerminalParms  (         2); break; //VT100
     case TY_CSI_PS('x',   1) :      reportTerminalParms  (         3); break; //VT100
 
-    case TY_CSI_PS_SP('q',   0) : emit titleChanged( 50, "CursorShape=0;BlinkingCursorEnabled=1" ); break;
-    case TY_CSI_PS_SP('q',   1) : emit titleChanged( 50, "CursorShape=0;BlinkingCursorEnabled=1" ); break;
-    case TY_CSI_PS_SP('q',   2) : emit titleChanged( 50, "CursorShape=0;BlinkingCursorEnabled=0" ); break;
-    case TY_CSI_PS_SP('q',   3) : emit titleChanged( 50, "CursorShape=1;BlinkingCursorEnabled=1" ); break;
-    case TY_CSI_PS_SP('q',   4) : emit titleChanged( 50, "CursorShape=1;BlinkingCursorEnabled=0" ); break;
-    case TY_CSI_PS_SP('q',   5) : emit titleChanged( 50, "CursorShape=2;BlinkingCursorEnabled=1" ); break;
-    case TY_CSI_PS_SP('q',   6) : emit titleChanged( 50, "CursorShape=2;BlinkingCursorEnabled=0" ); break;
+    case TY_CSI_PS_SP('q',   0) : /* fall through */
+    case TY_CSI_PS_SP('q',   1) : emit cursorChanged(KeyboardCursorShape::BlockCursor,     true ); break;
+    case TY_CSI_PS_SP('q',   2) : emit cursorChanged(KeyboardCursorShape::BlockCursor,     false); break;
+    case TY_CSI_PS_SP('q',   3) : emit cursorChanged(KeyboardCursorShape::UnderlineCursor, true ); break;
+    case TY_CSI_PS_SP('q',   4) : emit cursorChanged(KeyboardCursorShape::UnderlineCursor, false); break;
+    case TY_CSI_PS_SP('q',   5) : emit cursorChanged(KeyboardCursorShape::IBeamCursor,     true ); break;
+    case TY_CSI_PS_SP('q',   6) : emit cursorChanged(KeyboardCursorShape::IBeamCursor,     false); break;
 
     case TY_CSI_PN('@'      ) : _currentScreen->insertChars          (p         ); break;
     case TY_CSI_PN('A'      ) : _currentScreen->cursorUp             (p         ); break; //VT100

--- a/lib/qtermwidget.cpp
+++ b/lib/qtermwidget.cpp
@@ -318,13 +318,14 @@ void QTermWidget::init(int startnow)
     m_searchBar->setFont(font);
 
     setScrollBarPosition(NoScrollBar);
-    setKeyboardCursorShape(BlockCursor);
+    setKeyboardCursorShape(Emulation::KeyboardCursorShape::BlockCursor);
 
     m_impl->m_session->addView(m_impl->m_terminalDisplay);
 
     connect(m_impl->m_session, SIGNAL(resizeRequest(QSize)), this, SLOT(setSize(QSize)));
     connect(m_impl->m_session, SIGNAL(finished()), this, SLOT(sessionFinished()));
     connect(m_impl->m_session, &Session::titleChanged, this, &QTermWidget::titleChanged);
+    connect(m_impl->m_session, &Session::cursorChanged, this, &QTermWidget::cursorChanged);
 }
 
 
@@ -690,6 +691,13 @@ void QTermWidget::setKeyboardCursorShape(KeyboardCursorShape shape)
     m_impl->m_terminalDisplay->setKeyboardCursorShape(shape);
 }
 
+void QTermWidget::setBlinkingCursor(bool blink)
+{
+    if (!m_impl->m_terminalDisplay)
+        return;
+    m_impl->m_terminalDisplay->setBlinkingCursor(blink);
+}
+
 QString QTermWidget::title() const
 {
     QString title = m_impl->m_session->userTitle();
@@ -714,4 +722,11 @@ bool QTermWidget::isTitleChanged() const
 void QTermWidget::setAutoClose(bool autoClose)
 {
     m_impl->m_session->setAutoClose(autoClose);
+}
+
+void QTermWidget::cursorChanged(Konsole::Emulation::KeyboardCursorShape cursorShape, bool blinkingCursorEnabled)
+{
+    // TODO: A switch to enable/disable DECSCUSR?
+    setKeyboardCursorShape(cursorShape);
+    setBlinkingCursor(blinkingCursorEnabled);
 }

--- a/lib/qtermwidget.h
+++ b/lib/qtermwidget.h
@@ -22,6 +22,7 @@
 
 #include <QTranslator>
 #include <QWidget>
+#include "Emulation.h"
 #include "Filter.h"
 #include "qtermwidget_export.h"
 
@@ -46,24 +47,8 @@ public:
         ScrollBarRight = 2
     };
 
-    /**
-     * This enum describes the available shapes for the keyboard cursor.
-     * See setKeyboardCursorShape()
-     */
-    enum KeyboardCursorShape {
-        /** A rectangular block which covers the entire area of the cursor character. */
-        BlockCursor = 0,
-        /**
-         * A single flat line which occupies the space at the bottom of the cursor
-         * character's area.
-         */
-        UnderlineCursor = 1,
-        /**
-         * An cursor shaped like the capital letter 'I', similar to the IBeam
-         * cursor used in Qt/KDE text editors.
-         */
-        IBeamCursor = 2
-    };
+    // For backward API compatibility
+    using KeyboardCursorShape = Konsole::Emulation::KeyboardCursorShape;
 
     //Creation of widget
     QTermWidget(int startnow, // 1 = start shell programm immediatelly
@@ -213,6 +198,8 @@ public:
      */
     void setKeyboardCursorShape(KeyboardCursorShape shape);
 
+    void setBlinkingCursor(bool blink);
+
 
     /**
      * Automatically close the terminal session after the shell process exits or
@@ -299,6 +286,11 @@ private slots:
     void findPrevious();
     void matchFound(int startColumn, int startLine, int endColumn, int endLine);
     void noMatchFound();
+    /**
+     * Emulation::cursorChanged() signal propogates to here and QTermWidget
+     * sends the specified cursor states to the terminal display
+     */
+    void cursorChanged(Konsole::Emulation::KeyboardCursorShape cursorShape, bool blinkingCursorEnabled);
 
 private:
     void search(bool forwards, bool next);

--- a/lib/qtermwidget.h
+++ b/lib/qtermwidget.h
@@ -47,7 +47,6 @@ public:
         ScrollBarRight = 2
     };
 
-    // For backward API compatibility
     using KeyboardCursorShape = Konsole::Emulation::KeyboardCursorShape;
 
     //Creation of widget


### PR DESCRIPTION
Fixes #128, https://github.com/lxde/qterminal/issues/259 and https://github.com/lxde/qterminal/issues/289

Note that Neovim's cursor shaping is currently broken and I have to apply https://github.com/neovim/neovim/pull/6997 for testing.

To manually test it:
```
echo -e "\e[0 q"  # blinking block
echo -e "\e[1 q"  # blinking block
echo -e "\e[2 q"  # steady block
echo -e "\e[3 q"  # blinking underline
echo -e "\e[4 q"  # steady underline
echo -e "\e[5 q"  # blinking I-beam
echo -e "\e[6 q"  # steady I-beam
```