### PR TITLE
Fix build issue related to utmpx in Mac OSX Sierra

### DIFF
--- a/lib/kpty.cpp
+++ b/lib/kpty.cpp
@@ -503,7 +503,11 @@ void KPty::login(const char * user, const char * remotehost)
     // note: strncpy without terminators _is_ correct here. man 4 utmp
 
     if (user) {
+# ifdef HAVE_UTMPX
+        strncpy(l_struct.ut_user, user, sizeof(l_struct.ut_user));
+# else
         strncpy(l_struct.ut_name, user, sizeof(l_struct.ut_name));
+# endif
     }
 
     if (remotehost) {
@@ -614,7 +618,11 @@ void KPty::logout()
     setutent();
     if ((ut = getutline(&l_struct))) {
 #  endif
+#  ifdef HAVE_UTMPX
+        memset(ut->ut_user, 0, sizeof(*ut->ut_user));
+#  else
         memset(ut->ut_name, 0, sizeof(*ut->ut_name));
+#  endif
         memset(ut->ut_host, 0, sizeof(*ut->ut_host));
 #  ifdef HAVE_STRUCT_UTMP_UT_SYSLEN
         ut->ut_syslen = 0;


### PR DESCRIPTION
qtermwidget wouldn't build on OSX Sierra cause of changes in the utmpx struct. name=>user.

this seems to be the case with freebsd as well.