### PR TITLE
Support REP escape sequence defined in ECMA-48, section 8.3.103

### DIFF
--- a/lib/Screen.cpp
+++ b/lib/Screen.cpp
@@ -226,6 +226,28 @@ void Screen::insertChars(int n)
         screenLines[cuY].resize(columns);
 }
 
+void Screen::repeatChars(int count)
+    //=REP
+{
+    if (count == 0)
+    {
+        count = 1;
+    }
+    /**
+     * From ECMA-48 version 5, section 8.3.103
+     * If the character preceding REP is a control function or part of a
+     * control function, the effect of REP is not defined by this Standard.
+     *
+     * So, a "normal" program should always use REP immediately after a visible
+     * character (those other than escape sequences). So, lastDrawnChar can be
+     * safely used.
+     */
+    for (int i = 0; i < count; i++)
+    {
+        displayCharacter(lastDrawnChar);
+    }
+}
+
 void Screen::deleteLines(int n)
 {
     if (n == 0) n = 1; // Default
@@ -662,6 +684,8 @@ void Screen::displayCharacter(unsigned short c)
     currentChar.foregroundColor = effectiveForeground;
     currentChar.backgroundColor = effectiveBackground;
     currentChar.rendition = effectiveRendition;
+
+    lastDrawnChar = c;
 
     int i = 0;
     int newCursorX = cuX + w--;

--- a/lib/Screen.h
+++ b/lib/Screen.h
@@ -198,6 +198,11 @@ public:
      */
     void insertChars(int n);
     /**
+     * Repeat the preceeding graphic character @count times, including SPACE.
+     * If @count is 0 then the character is repeated once.
+     */
+    void repeatChars(int count);
+    /**
      * Removes @p n lines beginning from the current cursor position.
      * The position of the cursor is not altered.
      * If @p n is 0 then one line is removed.
@@ -666,6 +671,9 @@ private:
 
     // last position where we added a character
     int lastPos;
+
+    // used in REP (repeating char)
+    unsigned short lastDrawnChar;
 
     static Character defaultChar;
 };

--- a/lib/Vt102Emulation.cpp
+++ b/lib/Vt102Emulation.cpp
@@ -224,7 +224,7 @@ void Vt102Emulation::initTokenizer()
     charClass[i] |= CTL;
   for(i = 32;i < 256; ++i)
     charClass[i] |= CHR;
-  for(s = (quint8*)"@ABCDGHILMPSTXZcdfry"; *s; ++s)
+  for(s = (quint8*)"@ABCDGHILMPSTXZbcdfry"; *s; ++s)
     charClass[*s] |= CPN;
   // resize = \e[8;<row>;<col>t
   for(s = (quint8*)"t"; *s; ++s)
@@ -667,6 +667,7 @@ void Vt102Emulation::processToken(int token, int p, int q)
     case TY_CSI_PN('T'      ) : _currentScreen->scrollDown           (p         ); break;
     case TY_CSI_PN('X'      ) : _currentScreen->eraseChars           (p         ); break;
     case TY_CSI_PN('Z'      ) : _currentScreen->backtab              (p         ); break;
+    case TY_CSI_PN('b'      ) : _currentScreen->repeatChars          (p         ); break;
     case TY_CSI_PN('c'      ) :      reportTerminalType   (          ); break; //VT100
     case TY_CSI_PN('d'      ) : _currentScreen->setCursorY           (p         ); break; //LINUX
     case TY_CSI_PN('f'      ) : _currentScreen->setCursorYX          (p,      q); break; //VT100


### PR DESCRIPTION
Since ncurses 20170729, supporting REP is necessary for terminals with
xterm compatibility (TERM=xterm or similar). This patch fixes layout
issues with htop. [1]

Before:
![before](https://user-images.githubusercontent.com/1937689/29808446-ae3f2156-8cca-11e7-9ec8-fe4464dfaff0.png)

After:
![after](https://user-images.githubusercontent.com/1937689/29808445-ae04eb08-8cca-11e7-9663-18210890d5c5.png)

The ECMA-48 document I refer to can be found at [2]

[1] http://lists.gnu.org/archive/html/bug-ncurses/2017-08/msg00051.html
[2] http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-048.pdf