### PR TITLE
Check if utempter.h header exists (mainly for FreeBSD)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ include(GNUInstallDirs)
 include(GenerateExportHeader)
 include(CMakePackageConfigHelpers)
 include(CheckFunctionExists)
+include(CheckIncludeFile)
 
 set(REQUIRED_QT_VERSION "5.6")
 set(LXQTBT_MINIMUM_VERSION "0.4.0")
@@ -112,6 +113,7 @@ message(STATUS "Translations will be installed in: ${TRANSLATIONS_DIR}")
 set(QTERMWIDGET_INCLUDE_DIR "${CMAKE_INSTALL_FULL_INCLUDEDIR}/${QTERMWIDGET_LIBRARY_NAME}")
 
 CHECK_FUNCTION_EXISTS(updwtmpx HAVE_UPDWTMPX)
+CHECK_INCLUDE_FILE(utempter.h HAVE_UTEMPTER)
 
 qt5_wrap_cpp(MOCS ${HDRS})
 qt5_wrap_ui(UI_SRCS ${UI})
@@ -158,6 +160,14 @@ if(HAVE_UPDWTMPX)
         PRIVATE
             "HAVE_UPDWTMPX"
     )
+endif()
+
+if(HAVE_UTEMPTER)
+    target_compile_definitions(${QTERMWIDGET_LIBRARY_NAME}
+        PRIVATE
+            "HAVE_UTEMPTER"
+    )
+    target_link_libraries(${QTERMWIDGET_LIBRARY_NAME} ulog)
 endif()
 
 if (UTF8PROC_FOUND)


### PR DESCRIPTION
Check utempter.h header in CMakeLists.txt (it's only for FreeBSD users, others BSD do not have this file). There is already conditionnal test in [lib/kpty.cpp](https://github.com/lxde/qtermwidget/blob/master/lib/kpty.cpp#L82), but not in CMakeList.txt.

It avoid to use CFLAGS (for compilation stage). I used CheckIncludeFile macro, because if I test a function (e.g., addToUtmp which is present in this header) test fails.