### PR TITLE
Fix behavior of scroll up (SU)

### DIFF
--- a/lib/Screen.cpp
+++ b/lib/Screen.cpp
@@ -751,13 +751,18 @@ QRect Screen::lastScrolledRegion() const
 
 void Screen::scrollUp(int from, int n)
 {
-    if (n <= 0 || from + n > _bottomMargin) return;
+    if (n <= 0)
+        return;
+    if (from > _bottomMargin)
+        return;
+    if (from + n > _bottomMargin)
+        n = _bottomMargin + 1 - from;
 
     _scrolledLines -= n;
     _lastScrolledRegion = QRect(0,_topMargin,columns-1,(_bottomMargin-_topMargin));
 
     //FIXME: make sure `topMargin', `bottomMargin', `from', `n' is in bounds.
-    moveImage(loc(0,from),loc(0,from+n),loc(columns-1,_bottomMargin));
+    moveImage(loc(0,from),loc(0,from+n),loc(columns,_bottomMargin));
     clearImage(loc(0,_bottomMargin-n+1),loc(columns-1,_bottomMargin),' ');
 }
 


### PR DESCRIPTION
This is a backport of https://github.com/KDE/konsole/commit/7ff23512fd6c6af1dba87083446f85baf75e9c71

With tmux 2.6, screen layout is often broken. An example steps to reproduce:
1. Launch tmux
2. Run nvim and edit a long file (e.g., ```/usr/include/stdio.h```)
3. Hit page down

![image](https://user-images.githubusercontent.com/1937689/32122734-f86feb0a-bb93-11e7-92e9-d4f608b0ac6a.png)

This patch fixes the issue.