### PR TITLE
Finish SGR mouse protocol (1006)

### DIFF
--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -2324,9 +2324,9 @@ void TerminalDisplay::mouseReleaseEvent(QMouseEvent* ev)
       //       applies here, too.
 
       if (!_mouseMarks && !(ev->modifiers() & Qt::ShiftModifier))
-        emit mouseSignal( 3, // release
+        emit mouseSignal( 0,
                         charColumn + 1,
-                        charLine + 1 +_scrollBar->value() -_scrollBar->maximum() , 0);
+                        charLine + 1 +_scrollBar->value() -_scrollBar->maximum() , 2);
     }
     dragInfo.state = diNone;
   }
@@ -2336,10 +2336,10 @@ void TerminalDisplay::mouseReleaseEvent(QMouseEvent* ev)
        ((ev->button() == Qt::RightButton && !(ev->modifiers() & Qt::ShiftModifier))
                         || ev->button() == Qt::MidButton) )
   {
-    emit mouseSignal( 3,
+    emit mouseSignal( ev->button() == Qt::MidButton ? 1 : 2,
                       charColumn + 1,
                       charLine + 1 +_scrollBar->value() -_scrollBar->maximum() ,
-                      0);
+                      2);
   }
 }
 

--- a/lib/Vt102Emulation.cpp
+++ b/lib/Vt102Emulation.cpp
@@ -922,17 +922,22 @@ void Vt102Emulation::reportAnswerBack()
 
 void Vt102Emulation::sendMouseEvent( int cb, int cx, int cy , int eventType )
 {
-  if (cx < 1 || cy < 1)
-    return;
+    if (cx < 1 || cy < 1)
+      return;
 
-  // normal buttons are passed as 0x20 + button,
-  // mouse wheel (buttons 4,5) as 0x5c + button
-  if (cb >= 4)
-    cb += 0x3c;
+    // With the exception of the 1006 mode, button release is encoded in cb.
+    // Note that if multiple extensions are enabled, the 1006 is used, so it's okay to check for only that.
+    if (eventType == 2 && !getMode(MODE_Mouse1006))
+        cb = 3;
 
-  //Mouse motion handling
-  if ((getMode(MODE_Mouse1002) || getMode(MODE_Mouse1003)) && eventType == 1)
-    cb += 0x20; //add 32 to signify motion event
+    // normal buttons are passed as 0x20 + button,
+    // mouse wheel (buttons 4,5) as 0x5c + button
+    if (cb >= 4)
+      cb += 0x3c;
+
+    //Mouse motion handling
+    if ((getMode(MODE_Mouse1002) || getMode(MODE_Mouse1003)) && eventType == 1)
+      cb += 0x20; //add 32 to signify motion event
 
     char command[32];
     command[0] = '\0';


### PR DESCRIPTION
Some codes in https://github.com/KDE/konsole/commit/c83e7b638dcc42b617a067e6dc23686eccf23b00
are missing. Backport all of them.

Fixes #164

Test: install ncurses 6.1, run htop and click on a process

Also fixed identation, so there are no more "misleading identation" warnings from GCC.