### PR TITLE
Fix "bold and intensive" colors

### DIFF
--- a/lib/CharacterColor.h
+++ b/lib/CharacterColor.h
@@ -205,13 +205,13 @@ public:
   }
 
   /**
-   * Toggles the value of this color between a normal system color and the corresponding intensive
-   * system color.
+   * Set the value of this color from a normal system color to the corresponding intensive
+   * system color if it's not already an intensive system color.
    *
    * This is only applicable if the color is using the COLOR_SPACE_DEFAULT or COLOR_SPACE_SYSTEM
    * color spaces.
    */
-  void toggleIntensive();
+  void setIntensive();
 
   /**
    * Returns the color within the specified color @p palette
@@ -287,11 +287,11 @@ inline QColor CharacterColor::color(const ColorEntry* base) const
   return QColor();
 }
 
-inline void CharacterColor::toggleIntensive()
+inline void CharacterColor::setIntensive()
 {
   if (_colorSpace == COLOR_SPACE_SYSTEM || _colorSpace == COLOR_SPACE_DEFAULT)
   {
-    _v = !_v;
+    _v = 1;
   }
 }
 

--- a/lib/Screen.cpp
+++ b/lib/Screen.cpp
@@ -419,7 +419,7 @@ void Screen::updateEffectiveRendition()
     }
 
     if (currentRendition & RE_BOLD)
-        effectiveForeground.toggleIntensive();
+        effectiveForeground.setIntensive();
 }
 
 void Screen::copyFromHistory(Character* dest, int startLine, int count) const


### PR DESCRIPTION
For example, \e[0;1m\e[90m should give bold gray texts. It gave black.

Quick notes:
0 => reset all attributes
1 => use bold. In popular implementations (VTE3 & konsole), it also
changes a normal color to an intense color
90 => color0, intense; usually gray

This is already fixed in konsole:
https://github.com/KDE/konsole/commit/771b4b22289d928f77d0a3bda9762b8137f2407c

I happen to use the same function name :)

---

This should fix the problem I mentioned in https://github.com/lxde/qterminal/pull/401#issuecomment-364644465